### PR TITLE
Add Scorecard workflow for supply-chain security analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,16 +13,19 @@ on:
     - cron: '28 11 * * 2'
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
-# Declare default permissions as read only.
-permissions: read-all
+# Declare default permissions as read only and least-privilege.
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
-    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    if: github.event.repository.default_branch == github.ref_name
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -73,6 +76,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@33119e582d3ab4ed79c2610af108cb08ff983917 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This workflow runs Scorecard analysis for supply-chain security on the main branch and schedules it weekly.